### PR TITLE
Exposing options object

### DIFF
--- a/scripts/class-diagram.js
+++ b/scripts/class-diagram.js
@@ -60,7 +60,7 @@ function parseYumlExpr(specLine) {
         tokens = part.split("-");
       }
 
-      if (tokens.length !== 2) throw "Invalid expression";
+      if (tokens.length !== 2) throw new Error(`Invalid expression - ${JSON.stringify(tokens)}.`);
 
       const left = tokens[0];
       const right = tokens[1];
@@ -99,7 +99,7 @@ function parseYumlExpr(specLine) {
       rtext = tokens[1];
 
       exprs.push(["edge", lstyle, ltext, rstyle, rtext, style]);
-    } else throw "Invalid expression";
+    } else throw new Error(`Invalid expression - ${part}.`);
   }
 
   return exprs;

--- a/scripts/deployment-diagram.js
+++ b/scripts/deployment-diagram.js
@@ -40,7 +40,7 @@ function parseYumlExpr(specLine) {
       // line w/ or wo/ label
       part = part.substr(0, part.length - 1).trim();
       exprs.push(["edge", "none", "none", part, "solid"]);
-    } else throw "Invalid expression";
+    } else throw new Error(`Invalid expression - ${part}.`);
   }
 
   return exprs;

--- a/scripts/package-diagram.js
+++ b/scripts/package-diagram.js
@@ -42,7 +42,7 @@ function parseYumlExpr(specLine) {
       // line w/ or wo/ label
       part = part.substr(0, part.length - 2).trim();
       exprs.push(["edge", "none", "vee", part, "dashed"]);
-    } else throw "Invalid expression";
+    } else throw new Error(`Invalid expression - ${part}.`);
   }
 
   return exprs;

--- a/scripts/state-diagram.js
+++ b/scripts/state-diagram.js
@@ -44,7 +44,7 @@ function parseYumlExpr(specLine) {
     } else if (part === "-") {
       // connector for notes
       exprs.push(["edge", "none", "none", "", "solid"]);
-    } else throw "Invalid expression";
+    } else throw new Error(`Invalid expression - ${part}.`);
   }
 
   return exprs;

--- a/scripts/usecase-diagram.js
+++ b/scripts/usecase-diagram.js
@@ -55,7 +55,7 @@ function parseYumlExpr(specLine) {
           exprs.push(["edge", "none", "", "empty", "solid"]);
           break;
         default:
-          throw "Invalid expression";
+          throw new Error(`Invalid expression - ${part}.`);
       }
   }
 

--- a/scripts/yumldoc-utils.js
+++ b/scripts/yumldoc-utils.js
@@ -21,10 +21,17 @@ const SVGError = errorMessage =>
  * Generates SVG diagram.
  * @param {string} text The yUML document to parse
  * @param {boolean} isDark
+ * @param {object} [options] - The options to be set for generating the SVG
+ * @param {string} [options.dir] - The direction of the diagram "TB" (default) - topDown, "LR" - leftToRight, "RL" - rightToLeft
+ * @param {string} [options.type] - The type of SVG - "class" (default), "usecase", "activity", "state", "deployment", "package".
+ * @param {boolean} [options.generate] - Indicates if a .svg file shall be generated on each save.
  */
-const processYumlDocument = function(text, isDark) {
+const processYumlDocument = function(text, isDark, options) {
   const newlines = [];
-  const options = { dir: "TB", generate: false };
+  if (!options) options = {};
+  if (!options.dir) options.dir = "TB";
+  if (!options.type) options.type = "class";
+  if (options.generate === null || options.generate === undefined) options.generate = false;
 
   const lines = text.split(/\r|\n/).map(line => line.trim());
 


### PR DESCRIPTION
This PR solves two issues
- It exposes the options object so that users can set the options to provide type, dir and generate options, otherwise we get an error in the generated svg as mentioned below and there is no way to set the type.
```
<svg xmlns='http://www.w3.org/2000/svg' width='350' height='30'><text fill='red' x='10' y='20'>Error: Missing mandatory 'type' directive</text></svg>
```
- At times, I got an error `Inavlid expression`. However, I had no clue what was wrong and what is the error stack for me to point and debug. With the changes in the second commit, this becomes much better.
```
Error: Invalid expression [ModelClass
    at parseYumlExpr (/Users/amarz/sdk/tmpd/node_modules/yuml2svg/scripts/class-diagram.js:102:18)
    at composeDotExpr (/Users/amarz/sdk/tmpd/node_modules/yuml2svg/scripts/class-diagram.js:117:18)
    at processYumlDocument (/Users/amarz/sdk/tmpd/node_modules/yuml2svg/scripts/yumldoc-utils.js:54:15)
    at /Users/amarz/sdk/tmpd/test.js:8:17
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:511:3)
```